### PR TITLE
feat: add passive query logging for ACE telemetry

### DIFF
--- a/src/ragling/query_logger.py
+++ b/src/ragling/query_logger.py
@@ -1,0 +1,54 @@
+"""Append-only query logging for ACE telemetry."""
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def log_query(
+    log_path: Path,
+    query: str,
+    filters: dict[str, Any],
+    top_k: int,
+    results: list[dict[str, Any]],
+    duration_ms: float,
+) -> None:
+    """Append a query log entry as a single JSONL line.
+
+    Flushes and fsyncs after each write so ``tail -f`` consumers
+    see entries immediately.
+    """
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "query": query,
+        "filters": {k: v for k, v in filters.items() if v is not None},
+        "top_k": top_k,
+        "results": [
+            {
+                "rank": i,
+                "title": r.get("title", ""),
+                "source_path": r.get("source_path", ""),
+                "source_type": r.get("source_type", ""),
+                "collection": r.get("collection", ""),
+                "rrf_score": r.get("score", 0),
+            }
+            for i, r in enumerate(results)
+        ],
+        "duration_ms": round(duration_ms, 1),
+    }
+
+    try:
+        fd = os.open(str(log_path), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+        try:
+            line = json.dumps(entry, separators=(",", ":")) + "\n"
+            os.write(fd, line.encode())
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+    except OSError:
+        logger.warning("Failed to write query log to %s", log_path, exc_info=True)


### PR DESCRIPTION
## Summary
- Append-only JSONL log of every search query with results, RRF scores, ranks, filters, and timing
- New `query_logger.py` module: `log_query()` appends one JSONL line per search, uses `os.fsync()` for immediate flush (supports `tail -f` consumers)
- Config: `query_log_path` defaults to `{db_dir}/query_log.jsonl`, set to `null` in config JSON to disable
- MCP server: instruments `rag_search` with timing and logging hook at the MCP boundary (search internals unchanged)

Designed for downstream ACE (Agentic Collaborative Ensemble) Reflector consumption — the Reflector correlates search patterns with learning outcomes to improve retrieval quality.

## Example log entry
```json
{
  "timestamp": "2026-02-20T14:32:01.123Z",
  "query": "zig allocator free pattern",
  "filters": {"collection": "zig-expert"},
  "top_k": 10,
  "results": [
    {"rank": 0, "title": "Allocator Patterns", "source_path": "src/alloc.zig", "source_type": "code", "collection": "zig-expert", "rrf_score": 0.0231},
    {"rank": 1, "title": "Memory Safety", "source_path": "src/mem.zig", "source_type": "code", "collection": "zig-expert", "rrf_score": 0.0189}
  ],
  "duration_ms": 71.3
}
```

## Test plan
- [ ] Verify log file is created on first search when `query_log_path` is not set (default)
- [ ] Verify `tail -f` sees entries immediately (fsync flush)
- [ ] Verify setting `"query_log_path": null` in config disables logging
- [ ] Verify log entries contain all top_k results with correct ranks and scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)