### PR TITLE
Handle malformed config JSON gracefully

### DIFF
--- a/src/ragling/config.py
+++ b/src/ragling/config.py
@@ -180,8 +180,12 @@ def load_config(path: Path | None = None) -> Config:
 
     if config_path.exists():
         logger.info("Loading config from %s", config_path)
-        with open(config_path) as f:
-            data = json.load(f)
+        try:
+            with open(config_path) as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            logger.error("Failed to load config from %s: %s — using defaults", config_path, e)
+            data = {}
     else:
         logger.info("No config file found at %s, using defaults", config_path)
         data = {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 """Tests for ragling.config module."""
 
 import json
+import logging
 from pathlib import Path
 from types import MappingProxyType
 
@@ -404,3 +405,37 @@ class TestEnrichmentConfig:
         ec = EnrichmentConfig()
         with pytest.raises(AttributeError):
             ec.image_description = False  # type: ignore[misc]
+
+
+class TestMalformedConfigFallback:
+    """load_config should fall back to defaults on malformed or unreadable config."""
+
+    def test_malformed_json_falls_back_to_defaults(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.json"
+        config_file.write_text("{not valid json!!!")
+        config = load_config(config_file)
+        # Key fields should have default values
+        assert config.embedding_model == "bge-m3"
+        assert config.group_name == "default"
+        assert config.obsidian_vaults == ()
+
+    def test_malformed_json_logs_error(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        config_file = tmp_path / "config.json"
+        config_file.write_text("{corrupt")
+        with caplog.at_level(logging.ERROR, logger="ragling.config"):
+            load_config(config_file)
+        assert any("Failed to load config" in msg for msg in caplog.messages)
+
+    def test_unreadable_config_falls_back_to_defaults(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.json"
+        config_file.write_text("{}")
+        config_file.chmod(0o000)
+        try:
+            config = load_config(config_file)
+            assert config.embedding_model == "bge-m3"
+            assert config.group_name == "default"
+            assert config.obsidian_vaults == ()
+        finally:
+            config_file.chmod(0o644)


### PR DESCRIPTION
## Summary

- Wrap `json.load()` in `load_config()` with a try/except for `json.JSONDecodeError` and `OSError`
- Log error and fall back to defaults instead of crashing the MCP server or CLI
- Add 3 tests: malformed JSON fallback, error logging, and unreadable file fallback

Closes #15

## Test plan

- [x] `test_malformed_json_falls_back_to_defaults` — corrupt JSON returns default config
- [x] `test_malformed_json_logs_error` — error is logged at ERROR level
- [x] `test_unreadable_config_falls_back_to_defaults` — permission-denied file returns default config
- [x] All 52 config tests pass
- [x] mypy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)