### PR TITLE
Fix test_system_watcher hang on macOS

### DIFF
--- a/tests/test_system_watcher.py
+++ b/tests/test_system_watcher.py
@@ -254,6 +254,7 @@ class TestStartSystemWatcher:
         config = Config(
             emclient_db_path=tmp_path / "emclient.db",
             embedding_dimensions=4,
+            disabled_collections=frozenset({"calibre", "rss"}),
         )
         queue = MagicMock()
 
@@ -262,8 +263,12 @@ class TestStartSystemWatcher:
 
         observer, _watcher = start_system_watcher(config, queue)
         assert observer.is_alive()
-        observer.stop()
-        observer.join(timeout=5)
+        # Observer is a daemon thread (set in production code), so it will be
+        # cleaned up when the process exits. Calling observer.stop() followed
+        # by observer.join() can hang indefinitely because watchdog's internal
+        # threads don't shut down cleanly. Just unschedule watches so the
+        # observer has nothing to do — the daemon thread exits with the process.
+        observer.unschedule_all()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Disable `calibre` and `rss` collections in `test_returns_observer_and_watcher` so the watchdog observer only watches `tmp_path`, not real system directories (e.g. NetNewsWire's macOS container path) that cause FSEvents to hang on `observer.start()`
- Replace `observer.stop()` + `observer.join(timeout=5)` with `observer.unschedule_all()` since the observer is a daemon thread and `join()` can block indefinitely on watchdog's internal threads

Closes #20

## Root cause
The test created a `Config` with only `emclient_db_path` set, leaving `netnewswire_db_path` at its default (a real system path). When that path exists on the machine, `get_watch_directories()` includes it, and watchdog's FSEvents backend hangs trying to start an observer on it.

## Test plan
- [x] `uv run pytest tests/test_system_watcher.py -v` — all 14 tests pass in ~3s (previously hung indefinitely)
- [x] `uv run mypy src/` — no issues
- [x] `uv run ruff check tests/test_system_watcher.py` — all checks passed
- [x] `uv run ruff format --check tests/test_system_watcher.py` — already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)