### PR TITLE
fix: remove .md and .txt from code extension map

### DIFF
--- a/src/ragling/parsers/code.py
+++ b/src/ragling/parsers/code.py
@@ -86,8 +86,6 @@ _CODE_EXTENSION_MAP: dict[str, str] = {
     ".htm": "html",
     ".css": "css",
     ".scss": "scss",
-    ".md": "markdown",
-    ".txt": "plaintext",
     ".csv": "csv",
     ".rst": "rst",
 }

--- a/tests/test_code_parser.py
+++ b/tests/test_code_parser.py
@@ -96,8 +96,8 @@ class TestCodeExtensionMap:
     def test_scss_is_code_file(self) -> None:
         assert is_code_file(Path("theme.scss")) is True
 
-    def test_markdown_is_code_file(self) -> None:
-        assert is_code_file(Path("readme.md")) is True
+    def test_markdown_is_not_code_file(self) -> None:
+        assert is_code_file(Path("readme.md")) is False
 
     def test_csv_is_code_file(self) -> None:
         assert is_code_file(Path("data.csv")) is True
@@ -108,8 +108,8 @@ class TestCodeExtensionMap:
     def test_pdf_is_not_code_file(self) -> None:
         assert is_code_file(Path("document.pdf")) is False
 
-    def test_txt_is_code_file(self) -> None:
-        assert is_code_file(Path("notes.txt")) is True
+    def test_txt_is_not_code_file(self) -> None:
+        assert is_code_file(Path("notes.txt")) is False
 
     def test_docx_is_not_code_file(self) -> None:
         assert is_code_file(Path("report.docx")) is False
@@ -234,11 +234,11 @@ class TestGetLanguage:
     def test_scss_returns_scss(self) -> None:
         assert get_language(Path("theme.scss")) == "scss"
 
-    def test_markdown_returns_markdown(self) -> None:
-        assert get_language(Path("readme.md")) == "markdown"
+    def test_markdown_returns_none(self) -> None:
+        assert get_language(Path("readme.md")) is None
 
-    def test_txt_returns_plaintext(self) -> None:
-        assert get_language(Path("notes.txt")) == "plaintext"
+    def test_txt_returns_none(self) -> None:
+        assert get_language(Path("notes.txt")) is None
 
     def test_csv_returns_csv(self) -> None:
         assert get_language(Path("data.csv")) == "csv"


### PR DESCRIPTION
## Summary

- Remove `.md` and `.txt` from `_CODE_EXTENSION_MAP` in `src/ragling/parsers/code.py`
- Update code parser tests to expect `.md` and `.txt` are no longer detected as code files

Fixes three test failures introduced by commit 7b13796:
- `test_only_indexes_code_files` -- README.md and data.txt were being indexed as code
- `test_empty_repo_no_files` -- empty repo with README.md reported indexed=1
- `test_docx_in_git_repo_gets_indexed` -- `_index_repo_documents()` skipped .md files because `is_code_file()` returned True

### Overlap analysis

Commit 7b13796 added several extensions that overlap with `_EXTENSION_MAP` in `project.py`. The overlap causes `_index_repo_documents()` to skip document files in git repos because the filter `ext in _EXTENSION_MAP and not is_code_file(item)` rejects them. Extensions affected:

| Extension | In `_CODE_EXTENSION_MAP` | In `_EXTENSION_MAP` | Fixed? |
|-----------|-------------------------|---------------------|--------|
| `.md`     | `"markdown"`            | `"markdown"`        | Yes -- removed |
| `.txt`    | `"plaintext"`           | `"plaintext"`       | Yes -- removed |
| `.html`/`.htm` | `"html"`           | `"html"`            | No -- kept (useful for code repos with HTML templates) |
| `.json`   | `"json"`                | `"plaintext"`       | No -- kept (useful for package.json, tsconfig.json, etc.) |
| `.csv`    | `"csv"`                 | `"csv"`             | No -- kept (Docling handles better, but no failing test) |

The `.html`, `.json`, and `.csv` overlaps exist but have no failing tests. If those need fixing, a follow-up issue can address them by either removing them from `_CODE_EXTENSION_MAP` or adjusting the filter logic in `_index_repo_documents()`.

Closes #18

## Test plan

- [x] 3 originally-failing tests now pass
- [x] All 458 tests in `test_git_indexer.py`, `test_project_indexer.py`, `test_code_parser.py` pass
- [x] mypy, ruff check, ruff format all pass on changed files
- [x] Markdown and plaintext parsing logic preserved in `parse_code_file()` for direct callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)